### PR TITLE
Explicitly set nginx client_temp_body_path

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,6 +28,7 @@ http {
     #gzip  on;
 
     client_max_body_size 50M;
+    client_body_temp_path /tmp/azuracast_nginx_client 1 1;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Setting client_temp_body_path to a new subdir of a known writable directory (/tmp). Resolves #1 .

Tested with:
`docker build --tag azuracast/azuracast_web_v2:latest .`
and then, from within the directory with docker-compose.yml:
`docker-compose up`

and then uploaded a file locally.