### PR TITLE
Tune the opcache revalidate setting

### DIFF
--- a/php/php.ini.tmpl
+++ b/php/php.ini.tmpl
@@ -8,3 +8,4 @@ memory_limit={{ default .Env.PHP_MEMORY_LIMIT "128M" }}
 [opcache]
 opcache.enable=1
 opcache.enable_cli=1
+opcache.revalidate_freq={{ default .Env.PHP_OPCACHE_REVALIDATE_FREQUENCY "60" }}


### PR DESCRIPTION
Since the code inside of the web docker container only changes on updates which restart the container we should increase the revalidate frequency of the opcache. I've set this to 60s and made it configurable so that this setting does not bother us when developing locally or testing manual changes on a live environment.